### PR TITLE
use v4 api for ident.me to make sure we use an IPv4 address for security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ security groups that require access for `let-me-in`.
 ## Usage
 
 By default `let-me-in` will look up your external IP address at
-http://ident.me/, and add the address to the named security group(s):
+http://v4.ident.me/, and add the address to the named security group(s):
 
 ```
 let-me-in my-security-group

--- a/let-me-in.go
+++ b/let-me-in.go
@@ -156,7 +156,7 @@ func main() {
 	if *cidr == "" {
 		ident := os.Getenv("LMI_IDENT_URL")
 		if ident == "" {
-			ident = "http://ident.me/"
+			ident = "http://v4.ident.me/"
 		}
 		ip := getMyIp(ident) + "/32"
 		cidr = &ip


### PR DESCRIPTION
Fixes https://github.com/rlister/let-me-in/issues/1
